### PR TITLE
Add per-step prompts in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zsh-shell-customizer
 
-> Seamlessly synchronize your terminal experience across macOS and Linux.  
+> Seamlessly synchronize your terminal experience across macOS and Linux.
 > Includes Zsh shell, Gruvbox Dark theme, Nerd Fonts, Powerlevel10k, plugins, and more.
 
 ---
@@ -10,20 +10,59 @@
 This setup script customizes your terminal environment consistently across **macOS and Linux** by:
 
 1. Ensuring Zsh is the default shell
-2. Installing the **Gruvbox Dark** terminal theme (manual terminal step)
+2. Optionally showing instructions for the **Gruvbox Dark** terminal theme
 3. Installing and configuring **Oh My Zsh**
 4. Installing **Hack Nerd Font**
-5. Installing **Powerlevel10k** theme and running its config wizard
+5. Installing **Powerlevel10k** theme
 6. Installing essential Zsh plugins:
    - `zsh-syntax-highlighting`
    - `zsh-autosuggestions`
 7. Installing `colorls` in a Ruby environment
 8. Adding aliases for `colorls`
-9. Providing interactive prompts for safe installation
+9. Prompting before each major step so you can skip optional parts
 
 ---
 
 ## 🚀 Quick Start
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/yourusername/zfs-terminal-sync/main/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/yourusername/zsh-shell-customizer/main/install.sh)"
+```
+
+The installer will prompt you for each action so you can choose what to install. Gruvbox instructions remain optional.
+
+---
+
+## ✅ Manual Tests
+
+After running the script:
+
+1. **Check the shell**
+
+   ```bash
+   echo $SHELL
+   ```
+
+   Ensure the output path ends with `zsh`.
+
+2. **Gruvbox instructions**
+   If you opted in, apply the Gruvbox Dark color scheme in your terminal settings.
+
+3. **Plugin directories**
+
+   ```bash
+   ls ~/.oh-my-zsh/custom/plugins
+   ```
+
+   Verify `zsh-syntax-highlighting` and `zsh-autosuggestions` exist.
+
+4. **Run colorls**
+
+   ```bash
+   cls
+   ```
+
+   The command should display a colorful directory listing.
+
+5. **Font and Powerlevel10k**
+   Start a new terminal session and confirm the Hack Nerd Font is selectable and that Powerlevel10k loads without errors.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -e
+
+prompt() {
+  read -rp "$1 [y/N] " ans
+  [[ $ans =~ ^([Yy]|yes)$ ]]
+}
+
+if ! prompt "Proceed with zsh-shell customization?"; then
+  echo "Aborted." && exit 0
+fi
+
+# 1. Set Zsh as default shell
+if command -v zsh >/dev/null 2>&1; then
+  if [ "$SHELL" != "$(command -v zsh)" ]; then
+    if prompt "Set Zsh as your default shell?"; then
+      echo "Changing shell to zsh..."
+      chsh -s "$(command -v zsh)"
+    fi
+  else
+    echo "Zsh is already the default shell."
+  fi
+else
+  echo "Zsh not found. Please install zsh first."
+fi
+
+echo
+# 2. Gruvbox instructions
+if prompt "Install Gruvbox Dark theme?"; then
+  cat <<'GRUV'
+To enable the Gruvbox Dark theme:
+1. Open your terminal preferences.
+2. Choose the Gruvbox Dark color scheme.
+3. Apply the theme and restart the terminal if needed.
+GRUV
+fi
+
+if prompt "Install Oh My Zsh?"; then
+  echo "Installing Oh My Zsh..."
+  if [ ! -d "$HOME/.oh-my-zsh" ]; then
+    RUNZSH=no CHSH=no sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  else
+    echo "Oh My Zsh already installed."
+  fi
+fi
+
+touch "$HOME/.zshrc"
+add_line() {
+  grep -qxF "$1" "$HOME/.zshrc" || echo "$1" >> "$HOME/.zshrc"
+}
+
+if prompt "Install Hack Nerd Font?"; then
+  echo "Installing Hack Nerd Font..."
+  FONT_DIR="$HOME/.local/share/fonts"
+  mkdir -p "$FONT_DIR"
+  curl -fLo /tmp/Hack.zip https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/Hack.zip
+  unzip -o /tmp/Hack.zip -d "$FONT_DIR" >/dev/null
+  fc-cache -fv "$FONT_DIR"
+fi
+
+if prompt "Install Powerlevel10k theme?"; then
+  echo "Installing Powerlevel10k theme..."
+  THEME_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"
+  if [ ! -d "$THEME_DIR" ]; then
+    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "$THEME_DIR"
+  fi
+  sed -i 's/^ZSH_THEME=.*/ZSH_THEME="powerlevel10k\/powerlevel10k"/' "$HOME/.zshrc"
+fi
+
+if prompt "Install zsh-syntax-highlighting plugin?"; then
+  echo "Installing zsh-syntax-highlighting..."
+  PLUG_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting"
+  if [ ! -d "$PLUG_DIR" ]; then
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$PLUG_DIR"
+  fi
+  grep -q zsh-syntax-highlighting "$HOME/.zshrc" || sed -i 's/plugins=(/plugins=(zsh-syntax-highlighting /' "$HOME/.zshrc"
+fi
+
+if prompt "Install zsh-autosuggestions plugin?"; then
+  echo "Installing zsh-autosuggestions..."
+  PLUG_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions"
+  if [ ! -d "$PLUG_DIR" ]; then
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$PLUG_DIR"
+  fi
+  grep -q zsh-autosuggestions "$HOME/.zshrc" || sed -i 's/plugins=(/plugins=(zsh-autosuggestions /' "$HOME/.zshrc"
+fi
+
+if prompt "Install colorls and aliases?"; then
+  echo "Installing colorls..."
+  if command -v gem >/dev/null 2>&1; then
+    gem install --user-install colorls
+    add_line "alias cls='colorls'"
+    add_line "alias l='colorls -lA'"
+    add_line "alias tree='colorls --tree'"
+  else
+    echo "Ruby gem not found. Please install Ruby first."
+  fi
+fi
+
+echo "\nInstallation complete. Restart your terminal or run 'exec zsh' to start using Zsh."


### PR DESCRIPTION
## Summary
- prompt before each installation step instead of running everything after one confirmation
- clarify README about interactive setup and update step list

## Testing
- `bash -n install.sh`
- ran `bash install.sh` and confirmed it prompts for each component

------
https://chatgpt.com/codex/tasks/task_e_686efe6d8f9c832ca07cb37c6ca61a3d